### PR TITLE
Preparing for v1.2.3

### DIFF
--- a/src/main/antlr4/io.github.zenwave360.zdl.antlr/Zdl.g4
+++ b/src/main/antlr4/io.github.zenwave360.zdl.antlr/Zdl.g4
@@ -80,6 +80,7 @@ MIN: 'min';
 MAX: 'max';
 MINLENGTH: 'minlength';
 MAXLENGTH: 'maxlength';
+EMAIL: 'email';
 PATTERN: 'pattern';
 OPTION_NAME: '@' [a-zA-Z_][a-zA-Z0-9_]*;
 
@@ -128,7 +129,7 @@ suffix_javadoc: JAVADOC;
 legacy_constants: LEGACY_CONSTANT*;
 
 // values
-keyword: ID | IMPORT | CONFIG | APIS | PLUGINS | DISABLED | ASYNCAPI | OPENAPI | ENTITY | AGGREGATE | INPUT | OUTPUT | EVENT | RELATIONSHIP | SERVICE | PARAM_ID | FOR | TO | WITH_EVENTS | WITH | REQUIRED | UNIQUE | MIN | MAX | MINLENGTH | MAXLENGTH | PATTERN;
+keyword: ID | IMPORT | CONFIG | APIS | PLUGINS | DISABLED | ASYNCAPI | OPENAPI | ENTITY | AGGREGATE | INPUT | OUTPUT | EVENT | RELATIONSHIP | SERVICE | PARAM_ID | FOR | TO | WITH_EVENTS | WITH | REQUIRED | UNIQUE | MIN | MAX | MINLENGTH | MAXLENGTH | EMAIL | PATTERN;
 
 complex_value: value | array | object;
 value: simple | object;

--- a/src/main/antlr4/io.github.zenwave360.zdl.antlr/Zdl.g4
+++ b/src/main/antlr4/io.github.zenwave360.zdl.antlr/Zdl.g4
@@ -250,8 +250,13 @@ aggregate_command_parameter: ID;
 service: javadoc? annotations SERVICE service_name FOR LPAREN service_aggregates RPAREN LBRACE service_method* RBRACE;
 service_name: ID;
 service_aggregates: ID (COMMA ID)*;
-service_method: javadoc? annotations service_method_name LPAREN service_method_parameter_id? COMMA? service_method_parameter? RPAREN service_method_return? with_events? suffix_javadoc?;
+service_method: javadoc? annotations service_method_name
+    LPAREN
+        (service_method_parameter_natural service_method_parameter_id | service_method_parameter_id)?
+        COMMA? service_method_parameter?
+    RPAREN service_method_return? with_events? suffix_javadoc?;
 service_method_name: ID;
+service_method_parameter_natural: '@natural';
 service_method_parameter_id: PARAM_ID;
 service_method_parameter: ID;
 service_method_return: ID | ID ARRAY | ID OPTIONAL;

--- a/src/main/antlr4/io.github.zenwave360.zdl.antlr/Zdl.g4
+++ b/src/main/antlr4/io.github.zenwave360.zdl.antlr/Zdl.g4
@@ -118,9 +118,9 @@ PATTERN_REGEX: '/' .*? '/' ; // TODO: improve regex
 ERRCHAR: . -> channel(HIDDEN);
 
 // Rules
-zdl: imports global_javadoc? legacy_constants config? apis? (policies | aggregate | entity | enum | input | output | event | relationships | service | service_legacy)* EOF;
+zdl: legacy_constants (import_ | config | apis | policies | aggregate | entity | enum | input | output | event | relationships | service | service_legacy)* EOF;
 
-imports: ('@import' LPAREN import_value RPAREN)*;
+import_: '@import' LPAREN import_value RPAREN;
 import_value: string;
 global_javadoc: JAVADOC;
 javadoc: JAVADOC;
@@ -139,7 +139,7 @@ pair: keyword COLON value;
 object: LBRACE pair (COMMA pair)* RBRACE;
 array: LBRACK? value (COMMA value)* RBRACK?;
 
-config: CONFIG config_body;
+config: global_javadoc? CONFIG config_body;
 config_body: LBRACE config_option* plugins? RBRACE;
 config_option: field_name complex_value;
 

--- a/src/main/java/io/github/zenwave360/zdl/antlr/ZdlListenerImpl.java
+++ b/src/main/java/io/github/zenwave360/zdl/antlr/ZdlListenerImpl.java
@@ -62,10 +62,8 @@ public class ZdlListenerImpl extends io.github.zenwave360.zdl.antlr.ZdlBaseListe
     }
 
     @Override
-    public void enterImports(io.github.zenwave360.zdl.antlr.ZdlParser.ImportsContext ctx) {
-        for (io.github.zenwave360.zdl.antlr.ZdlParser.Import_valueContext importValue : ctx.import_value()) {
-            model.appendToList("imports", getValueText(importValue.string()));
-        }
+    public void enterImport_(io.github.zenwave360.zdl.antlr.ZdlParser.Import_Context ctx) {
+        model.appendToList("imports", getValueText(ctx.import_value().string()));
     }
 
     @Override

--- a/src/main/java/io/github/zenwave360/zdl/antlr/ZdlListenerImpl.java
+++ b/src/main/java/io/github/zenwave360/zdl/antlr/ZdlListenerImpl.java
@@ -574,6 +574,7 @@ public class ZdlListenerImpl extends io.github.zenwave360.zdl.antlr.ZdlBaseListe
         var serviceName = getText(((io.github.zenwave360.zdl.antlr.ZdlParser.ServiceContext) ctx.getParent()).service_name());
         var methodName = getText(ctx.service_method_name());
         var location = "services." + serviceName + ".methods." + methodName;
+        var naturalId = ctx.service_method_parameter_natural() != null? true : null;
         var methodParamId = ctx.service_method_parameter_id() != null? "id" : null;
         var methodParameter = ctx.service_method_parameter() != null? ctx.service_method_parameter().getText() : null;
         var returnType = ctx.service_method_return() != null? ctx.service_method_return().ID().getText() : null;
@@ -585,6 +586,7 @@ public class ZdlListenerImpl extends io.github.zenwave360.zdl.antlr.ZdlBaseListe
         var method = new FluentMap()
                 .with("name", methodName)
                 .with("serviceName", serviceName)
+                .with("naturalId", naturalId)
                 .with("paramId", methodParamId)
                 .with("parameter", methodParameter)
                 .with("returnType", returnType)

--- a/src/test/java/io/github/zenwave360/zdl/antlr/ZdlListenerTest.java
+++ b/src/test/java/io/github/zenwave360/zdl/antlr/ZdlListenerTest.java
@@ -24,11 +24,16 @@ public class ZdlListenerTest {
 
     @Test
     public void parseZdl_SuffixJavadoc() throws Exception {
-
         ZdlModel model = parseZdl("src/test/resources/suffix_javadoc.zdl");
-
         System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(model));
     }
+
+    @Test
+    public void parseZdl_Composed() throws Exception {
+        ZdlModel model = parseZdl("src/test/resources/composed.zdl");
+        System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(model));
+    }
+
 
     @Test
     public void parseZdl_CompleteZdl() throws Exception {

--- a/src/test/resources/composed.zdl
+++ b/src/test/resources/composed.zdl
@@ -1,0 +1,23 @@
+/**
+* First Global Javadoc
+*/
+config {
+    title "First Title"
+}
+
+entity OneEntity {
+    oneField String
+    secondField String
+}
+
+/**
+* Seccond Global Javadoc
+*/
+config {
+    title "Second Title"
+}
+
+entity OneEntity {
+    oneField Long
+    thirdField String
+}


### PR DESCRIPTION
* 2024-12-12 10b50a2 adds support for `@natural id`
* 2024-12-12 c71ed0b flexibilities where `config`, `apis`, `imports` and `global_javadoc` may appear on the document, allowing zdl file concatenation.
* 2024-12-01 0a7ada0 adds support for `email` as validation constraint
